### PR TITLE
Add "translatable" to properties.schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The attributes listed below are used in *contentObject.json*, *articles.json*, *
 
 **_search** (object): Object to designate search settings.  
 
->**keywords** array(string): An array of strings detailing the important search phrases for the course section.
+>**keywords** array(string): An array of strings detailing the important search phrases for the course section.  
+**NOTE**: Keywords are not exported with the `grunt translate:export` command. When localising content, use a process that identifies keywords from the actual translated course content.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The attributes listed below are used in *contentObject.json*, *articles.json*, *
 **_search** (object): Object to designate search settings.  
 
 >**keywords** array(string): An array of strings detailing the important search phrases for the course section.  
-**NOTE**: Keywords are not exported with the `grunt translate:export` command. When localising content, use a process that identifies keywords from the actual translated course content.
+**NOTE**: Keywords are exported with the `grunt translate:export` command. When localising content, use a process that ensures translated keywords are found in the actual translated course content.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/properties.schema
+++ b/properties.schema
@@ -266,7 +266,8 @@
                                     "required": false,
                                     "title": "Title",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 },
                                 "description": {
                                     "type": "string",
@@ -274,7 +275,8 @@
                                     "required": false,
                                     "title": "Placeholder",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 },
                                 "placeholder": {
                                     "type": "string",
@@ -282,7 +284,8 @@
                                     "required": false,
                                     "title": "Placeholder text for the search box",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 },
                                 "noResultsMessage": {
                                     "type": "string",
@@ -290,7 +293,8 @@
                                     "required": false,
                                     "title": "No results message",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 },
                                 "awaitingResultsMessage": {
                                     "type": "string",
@@ -298,7 +302,8 @@
                                     "required": false,
                                     "title": "Processing results message",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 }
                             }
                         }

--- a/properties.schema
+++ b/properties.schema
@@ -33,7 +33,8 @@
                                     "required": false,
                                     "title": "Keywords",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 }
                             }
                         }
@@ -62,7 +63,8 @@
                                     "required": false,
                                     "title": "Keywords",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 }
                             }
                         }
@@ -91,7 +93,8 @@
                                     "required": false,
                                     "title": "Keywords",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 }
                             }
                         }
@@ -120,7 +123,8 @@
                                     "required": false,
                                     "title": "Keywords",
                                     "inputType": "Text",
-                                    "validators": []
+                                    "validators": [],
+                                    "translatable": true
                                 }
                             }
                         }


### PR DESCRIPTION
fixes #43 

Note: I added "translatable" to "keywords". Arguments can be made for and against included them. As a caution, I amended the README.