### PR TITLE
#3157 - removed tabindex from elements to stop the screenreader reading out empty group

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/cgkineo/adapt-search"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "framework": ">=5.5",
   "homepage": "https://github.com/cgkineo/adapt-search",
   "issues": "https://github.com/cgkineo/adapt-search/issues/",

--- a/templates/searchResultsContent.hbs
+++ b/templates/searchResultsContent.hbs
@@ -3,7 +3,7 @@
 {{else}}
 
 {{#if isAwaitingResults}}
-<div class="search__item no-results" aria-label="{{{awaitingResultsMessage}}}" role="region">
+<div class="search__item no-results" aria-label="{{{awaitingResultsMessage}}}">
   <div class="search__item-inner">
     {{{awaitingResultsMessage}}}
   </div>
@@ -50,7 +50,7 @@
 
 {{else}}
 
-<div class="search__item no-results" aria-label="{{{noResultsMessage}}}" role="region">
+<div class="search__item no-results" aria-label="{{{noResultsMessage}}}">
   <div class="search__item-inner">
     {{{noResultsMessage}}}
   </div>

--- a/templates/searchResultsContent.hbs
+++ b/templates/searchResultsContent.hbs
@@ -3,7 +3,7 @@
 {{else}}
 
 {{#if isAwaitingResults}}
-<div class="search__item no-results" tabindex="0" aria-label="{{{awaitingResultsMessage}}}" role="region">
+<div class="search__item no-results" aria-label="{{{awaitingResultsMessage}}}" role="region">
   <div class="search__item-inner">
     {{{awaitingResultsMessage}}}
   </div>
@@ -50,7 +50,7 @@
 
 {{else}}
 
-<div class="search__item no-results" tabindex="0" aria-label="{{{noResultsMessage}}}" role="region">
+<div class="search__item no-results" aria-label="{{{noResultsMessage}}}" role="region">
   <div class="search__item-inner">
     {{{noResultsMessage}}}
   </div>

--- a/templates/searchSingleItem.hbs
+++ b/templates/searchSingleItem.hbs
@@ -3,7 +3,7 @@
 
     {{#if title}}
     <div class="drawer__item-title">
-      <div class="drawer__item-title-inner" tabindex="0" aria-role="region">
+      <div class="drawer__item-title-inner" aria-role="region">
         {{{title}}}
       </div>
     </div>

--- a/templates/searchSingleItem.hbs
+++ b/templates/searchSingleItem.hbs
@@ -3,7 +3,7 @@
 
     {{#if title}}
     <div class="drawer__item-title">
-      <div class="drawer__item-title-inner" aria-role="region">
+      <div class="drawer__item-title-inner">
         {{{title}}}
       </div>
     </div>


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/3157