### PR TITLE
issue/109 Altering aria structure in drawer

### DIFF
--- a/js/searchResultsView.js
+++ b/js/searchResultsView.js
@@ -9,6 +9,12 @@ export default class SearchResultsView extends Backbone.View {
     return 'search__items-container is-inactive';
   }
 
+  attributes() {
+    return {
+      role: 'group'
+    };
+  }
+
   events() {
     return {
       'click [data-id]': 'navigateToResultPage'


### PR DESCRIPTION
[#109](https://github.com/adaptlearning/adapt-contrib-core/issues/109) The drawer__holder is taking on the role of 'list'. Recommending making the top level search element a 'group'. https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#list