### PR TITLE
Fix: Ignore invalid content (fixes #68)

### DIFF
--- a/js/SearchableModel.js
+++ b/js/SearchableModel.js
@@ -30,8 +30,8 @@ export default class SearchableModel {
     const type = this.model.get('_type');
     const shouldIgnore = hideTypes.includes(type) || (type === 'component' && hideComponents.includes(component));
     if (shouldIgnore) return false;
-    const displayTitle = this.model.get('displayTitle').trim();
-    const title = this.model.get('title').trim();
+    const displayTitle = this.model.get('displayTitle')?.trim();
+    const title = this.model.get('title')?.trim();
     const hasTitleOrDisplayTitle = Boolean(displayTitle || title);
     return hasTitleOrDisplayTitle;
   }

--- a/js/SearchablePhrase.js
+++ b/js/SearchablePhrase.js
@@ -31,17 +31,16 @@ export default class SearchablePhrase {
     const minimumWordLength = config._minimumWordLength;
     this.words = {};
     const matchedWords = this.safePhrase.match(matchNotWordBoundaries);
-    if (matchedWords !== null) {
-      this.words = matchedWords.map(chunk => chunk.replace(trimReplaceNonWordCharacters, ''))
-        .filter(word => word.length >= minimumWordLength)
-        .reduce((wordCounts, word) => {
-          word = word.toLowerCase();
-          if (ignoreWords.includes(word)) return wordCounts;
-          wordCounts[word] = wordCounts[word] || 0;
-          wordCounts[word]++;
-          return wordCounts;
-        }, {});
-    }
+    if (matchedWords === null) return;
+    this.words = matchedWords.map(chunk => chunk.replace(trimReplaceNonWordCharacters, ''))
+      .filter(word => word.length >= minimumWordLength)
+      .reduce((wordCounts, word) => {
+        word = word.toLowerCase();
+        if (ignoreWords.includes(word)) return wordCounts;
+        wordCounts[word] = wordCounts[word] || 0;
+        wordCounts[word]++;
+        return wordCounts;
+      }, {});
   }
 
   /**

--- a/js/SearchablePhrase.js
+++ b/js/SearchablePhrase.js
@@ -29,17 +29,19 @@ export default class SearchablePhrase {
       ? config._ignoreWords
       : config._ignoreWords.split(',');
     const minimumWordLength = config._minimumWordLength;
-    this.words = this.safePhrase
-      .match(matchNotWordBoundaries)
-      .map(chunk => chunk.replace(trimReplaceNonWordCharacters, ''))
-      .filter(word => word.length >= minimumWordLength)
-      .reduce((wordCounts, word) => {
-        word = word.toLowerCase();
-        if (ignoreWords.includes(word)) return wordCounts;
-        wordCounts[word] = wordCounts[word] || 0;
-        wordCounts[word]++;
-        return wordCounts;
-      }, {});
+    this.words = {};
+    const matchedWords = this.safePhrase.match(matchNotWordBoundaries);
+    if (matchedWords !== null) {
+      this.words = matchedWords.map(chunk => chunk.replace(trimReplaceNonWordCharacters, ''))
+        .filter(word => word.length >= minimumWordLength)
+        .reduce((wordCounts, word) => {
+          word = word.toLowerCase();
+          if (ignoreWords.includes(word)) return wordCounts;
+          wordCounts[word] = wordCounts[word] || 0;
+          wordCounts[word]++;
+          return wordCounts;
+        }, {});
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #68 

### Fix
* Ignores content (ex. `title`, `body`) if it does not contain any valid characters that pass the regex (ex. one or more alphanumeric characters).
* Suppresses error if `title` or `displayTitle` are missing completely

### Testing
First test
1. Add a `.`, `#`, or `...` to a component's `body` or `title` as the _only_ content.
2. Check the console for errors. You should _not_ see:

```
Uncaught TypeError: this.safePhrase.match(...) is null
```
Second test
1. Remove `title` and `displayTitle` completely from a component
2. Check the console for errors. You should _not_ see:

```
Uncaught TypeError: this.model.get(...) is undefined
```